### PR TITLE
Fix: #16 AI provider dropdown visibility issue

### DIFF
--- a/src/components/AIKeyManager.tsx
+++ b/src/components/AIKeyManager.tsx
@@ -596,7 +596,7 @@ export const AIKeyManager: React.FC = () => {
                       >
                         <SelectValue placeholder="Select provider" />
                       </SelectTrigger>
-                      <SelectContent>
+                      <SelectContent className="z-[9999] bg-slate-900 text-white border border-slate-700 shadow-lg ">
                         {aiProviders.map((provider) => (
                           <SelectItem key={provider.id} value={provider.id}>
                             <div className="flex items-center gap-2">


### PR DESCRIPTION
Fixes #16 

This pull request resolves the bug where the AI provider selection dropdown was rendering behind the "Add New API Key" form, making it unusable.

**Changes Made:**
- Applied appropriate Tailwind CSS classes (`z-[9999]`, `bg-slate-900`, `text-white`, `border`, `shadow-lg`) to the `SelectContent` component within `src/components/AIKeyManager.tsx`.
- This ensures the dropdown is properly layered and visually clear on both light and dark themes.

This significantly improves the user experience and accessibility of the AI Configuration page.