### PR TITLE
Scroll to top button added globally 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "code-guardian-report",
-  "version": "5.9",
+  "version": "6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "code-guardian-report",
-      "version": "5.9",
+      "version": "6.0",
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.3.2",
         "@radix-ui/react-collapsible": "^1.1.11",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import Lenis from '@studio-freight/lenis';
 
 // Lenis smooth scroll initialization with context for global access
 import { createContext, useContext, useRef as useReactRef } from "react";
+import { ScrollToTop } from "./components/scrollToTop";
 
 const LenisContext = createContext<Lenis | null>(null);
 
@@ -79,6 +80,7 @@ const App = () => (
           <PWAUpdateNotification />
           <OfflineIndicator />
           <SinglePageApp />
+          <ScrollToTop/>
           <Analytics />
         </SmoothScroll>
       </TooltipProvider>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { Shield, Heart, Mail, Github, Globe, Scale, FileText, Code, Building2, Brain, Star, Users, Youtube, Linkedin, ExternalLink, ArrowUp } from 'lucide-react';
+import { Shield, Heart, Mail, Github, Globe, Scale, FileText, Code, Building2, Brain, Star, Users, Youtube, Linkedin, ExternalLink } from 'lucide-react';
 import { APP_VERSION_WITH_PREFIX } from '@/utils/version';
-import { Button } from '@/components/ui/button';
 
 interface FooterProps {
   className?: string;
@@ -19,11 +18,6 @@ export const Footer: React.FC<FooterProps> = ({ className = '' }) => {
         block: 'start'
       });
     }
-  };
-
-  // Scroll to top
-  const scrollToTop = () => {
-    window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
   const footerLinks = {
@@ -230,19 +224,6 @@ export const Footer: React.FC<FooterProps> = ({ className = '' }) => {
               </div>
             </div>
           </div>
-        </div>
-
-        {/* Scroll to Top Button */}
-        <div className="mt-8 flex justify-center">
-          <Button
-            onClick={scrollToTop}
-            variant="ghost"
-            size="sm"
-            className="group p-3 rounded-full bg-slate-800/50 hover:bg-slate-700/50 text-slate-300 hover:text-white transition-all duration-300 border border-slate-700/50 hover:border-slate-600/50 hover:scale-110"
-            aria-label="Scroll to top"
-          >
-            <ArrowUp className="h-5 w-5 group-hover:-translate-y-1 transition-transform duration-300" />
-          </Button>
         </div>
       </div>
     </footer>

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+import { ArrowUp } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface ScrollToTopProps {
+  className?: string;
+}
+
+export const ScrollToTop: React.FC<ScrollToTopProps> = ({ className = "" }) => {
+  const [isVisible, setIsVisible] = useState(false);
+
+  // Show button only when user scrolls down
+  useEffect(() => {
+    const toggleVisibility = () => {
+      if (window.scrollY > 300) {
+        setIsVisible(true);
+      } else {
+        setIsVisible(false);
+      }
+    };
+
+    window.addEventListener("scroll", toggleVisibility);
+    return () => window.removeEventListener("scroll", toggleVisibility);
+  }, []);
+
+  // Scroll smoothly to top
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: "smooth",
+    });
+  };
+
+  if (!isVisible) return null; 
+
+  return (
+    <Button
+      onClick={scrollToTop}
+      variant="ghost"
+      size="sm"
+      className={`fixed bottom-6 right-6 z-50 group p-3 rounded-full 
+        bg-slate-800/50 hover:bg-slate-700/50 text-slate-300 hover:text-white 
+        transition-all duration-300 border border-slate-700/50 
+        hover:border-slate-600/50 hover:scale-110 ${className}`}
+      aria-label="Scroll to top"
+    >
+      <ArrowUp className="h-5 w-5 group-hover:-translate-y-1 transition-transform duration-300" />
+    </Button>
+  );
+};


### PR DESCRIPTION
This PR solves issue #45 

Fixes #45 

Earlier Version -:
<img width="1877" height="392" alt="image" src="https://github.com/user-attachments/assets/d9eb2c16-1ece-4d6f-821b-c2c7a57a0980" />

Current Version -:
<img width="1898" height="822" alt="image" src="https://github.com/user-attachments/assets/48cfab48-3daf-4882-bb3c-10a4108b271f" />

In current version the "Scroll to Top" button is visible and accessible globally, preferably fixed at the bottom-right corner of the screen when the user scrolls down past a certain point.