### PR TITLE
Implement automatic scroll-to-top on navigation - Fixes #63

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "code-guardian-report",
-  "version": "5.9",
+  "version": "6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "code-guardian-report",
-      "version": "5.9",
+      "version": "6.0",
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.3.2",
         "@radix-ui/react-collapsible": "^1.1.11",

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -36,6 +36,11 @@ export const Navigation: React.FC<NavigationProps> = ({ isDarkMode, toggleDarkMo
   const handleNavigate = (sectionId: string) => {
     navigateTo(sectionId);
     setIsMobileMenuOpen(false);
+
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth'
+    });
   };
 
   const navItems = [

--- a/src/lib/navigation-context.tsx
+++ b/src/lib/navigation-context.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, ReactNode } from 'react';
+import React, { createContext, useContext, useState, ReactNode, useEffect } from 'react';
 
 interface NavigationContextType {
   currentSection: string;
@@ -21,6 +21,13 @@ export const NavigationProvider: React.FC<NavigationProviderProps> = ({ children
   const [currentSection, setCurrentSection] = useState('home');
   const [currentTab, setCurrentTab] = useState('upload');
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false);
+
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth'
+    });
+  }, [currentSection]);
 
   const navigateTo = (section: string, tab?: string) => {
     setCurrentSection(section);


### PR DESCRIPTION
## Hey team! 👋

I've implemented the scroll-to-top feature that was mentioned in issue #63. Instead of adding it to each component, I put the logic in the `navigation-context` so it works consistently throughout the app.

### What I did:
- Added a `useEffect` in `navigation-context.tsx` that watches for section changes
- Implemented smooth scrolling for better UX
- Also add `scroll to top` in `Navigation.tsx` for scroll to same section like when user at bottom of `About` page it click on `about` so in this case scroll is also work  