### PR TITLE
Fix: Mobile Button Overlap in Legal Section (#120)

### DIFF
--- a/src/components/pages/legal/LegalPageClient.tsx
+++ b/src/components/pages/legal/LegalPageClient.tsx
@@ -59,12 +59,18 @@ export default function LegalPageClient() {
         onValueChange={handleTabChange}
         className="w-full"
       >
-        <TabsList className="mx-auto mb-8 grid w-full grid-cols-2 sm:w-[400px]">
-          <TabsTrigger value="privacy" className="flex items-center gap-2">
+        <TabsList className="mx-auto mb-8 grid h-auto w-full grid-cols-1 gap-2 p-2 sm:w-[400px] sm:grid-cols-2 sm:gap-0 sm:p-1">
+          <TabsTrigger
+            value="privacy"
+            className="flex w-full items-center justify-center gap-2 px-3 py-2 whitespace-nowrap"
+          >
             <Shield className="h-4 w-4" />
             Privacy Policy
           </TabsTrigger>
-          <TabsTrigger value="terms" className="flex items-center gap-2">
+          <TabsTrigger
+            value="terms"
+            className="flex w-full items-center justify-center gap-2 px-3 py-2 whitespace-nowrap"
+          >
             <FileText className="h-4 w-4" />
             Terms of Service
           </TabsTrigger>


### PR DESCRIPTION
Fix: Mobile Button Overlap in Legal Section

This PR resolves a UI responsiveness issue where buttons in the Legal section overlapped on smaller screens.

Changes Made
- Adjusted responsive Tailwind classes.
- Ensured vertical stacking on mobile.
- Improved spacing and alignment.
- Maintained desktop layout integrity.

Result
✔ No overlapping on mobile  
✔ Improved readability  
✔ Better responsive experience  

OSCG 26'